### PR TITLE
Ajuste la mise en page des cartes de demandes

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,20 +14,10 @@
   </head>
   <body>
     <header>
-      <div class="app-title">
-        <h1>Demandes rapides</h1>
-        <p>Exprimez les besoins essentiels en un tap, même hors-ligne.</p>
-      </div>
-      <div class="toolbar" role="toolbar" aria-label="Options de lecture">
-        <label class="range-field" for="volumeRange">
-          Volume
-          <input id="volumeRange" type="range" min="0" max="1" step="0.01" value="1" />
-        </label>
-        <button id="favoritesToggle" class="toggle-button" type="button" aria-pressed="false">
-          <span class="icon">★</span>
-          Favoris d'abord
-        </button>
-      </div>
+      <button id="favoritesToggle" class="toggle-button" type="button" aria-pressed="false">
+        <span class="icon">★</span>
+        Favoris d'abord
+      </button>
     </header>
 
     <main>
@@ -74,13 +64,16 @@
     </dialog>
 
     <template id="phraseTemplate">
-      <article class="phrase-card" draggable="true">
-        <button type="button" class="phrase-button"></button>
-        <div class="phrase-actions">
-          <button class="star" type="button" aria-label="Basculer en favori"></button>
-          <button class="edit" type="button" aria-label="Modifier"></button>
-        </div>
-      </article>
+      <div class="phrase-item">
+        <article class="phrase-card" draggable="true">
+          <button type="button" class="phrase-button"></button>
+          <div class="phrase-actions">
+            <button class="star" type="button" aria-label="Basculer en favori"></button>
+            <button class="edit" type="button" aria-label="Modifier"></button>
+          </div>
+        </article>
+        <p class="queue-indicator" hidden>MP3 en cours...</p>
+      </div>
     </template>
 
     <script type="module" src="./app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -35,34 +35,8 @@ header {
   backdrop-filter: blur(12px);
   border-bottom: 1px solid rgba(209, 213, 219, 0.6);
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
   align-items: center;
-  justify-content: space-between;
-}
-
-.app-title {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.app-title h1 {
-  margin: 0;
-  font-size: clamp(1.35rem, 3vw, 1.75rem);
-}
-
-.app-title p {
-  margin: 0;
-  font-size: 0.88rem;
-  color: var(--text-soft);
-}
-
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .toggle-button,
@@ -92,40 +66,35 @@ header {
   border-color: var(--accent);
 }
 
-.range-field {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.9rem;
-  color: var(--text-soft);
-}
-
-.range-field input[type="range"] {
-  accent-color: var(--accent);
-  width: 160px;
-}
-
 main {
   flex: 1;
   padding: 18px 16px 120px;
 }
 
 .phrase-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.phrase-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
 }
 
 .phrase-card {
   position: relative;
   background: var(--bg-card);
   border-radius: 20px;
-  padding: 6px;
+  padding: 12px 16px;
   box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
   border: 2px solid transparent;
   transition: border-color 160ms ease, transform 140ms ease;
   min-height: 120px;
   display: flex;
+  align-items: center;
 }
 
 .phrase-card.drag-over-top {
@@ -140,7 +109,7 @@ main {
   border-color: rgba(255, 178, 36, 0.6);
 }
 
-.phrase-card.is-playing {
+.phrase-card.is-active {
   border-color: var(--accent);
   box-shadow: 0 0 0 4px var(--accent-soft), var(--shadow-soft);
 }
@@ -168,8 +137,8 @@ main {
   color: inherit;
   font-size: 1.25rem;
   font-weight: 600;
-  padding: 18px;
-  border-radius: 16px;
+  padding: 12px 0;
+  border-radius: 12px;
   text-align: left;
   cursor: pointer;
   display: flex;
@@ -179,17 +148,16 @@ main {
 }
 
 .phrase-actions {
-  position: absolute;
-  top: 6px;
-  right: 6px;
   display: flex;
   gap: 6px;
+  margin-left: auto;
+  align-items: center;
 }
 
 .phrase-actions button {
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
   border: none;
   background: rgba(255, 255, 255, 0.85);
   color: var(--text-soft);
@@ -323,17 +291,10 @@ button.primary {
 }
 
 .queue-indicator {
-  position: absolute;
-  left: 16px;
-  bottom: 12px;
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  font-size: 0.78rem;
+  margin: 0;
+  padding-left: 16px;
+  font-size: 0.65rem;
   color: var(--text-soft);
-  background: rgba(15, 23, 42, 0.08);
-  padding: 4px 10px;
-  border-radius: 999px;
 }
 
 .queue-indicator .dot {
@@ -342,6 +303,8 @@ button.primary {
   border-radius: 50%;
   background: var(--accent);
   animation: pulse 1.1s ease-in-out infinite;
+  display: inline-block;
+  margin-right: 6px;
 }
 
 @keyframes pulse {
@@ -364,15 +327,9 @@ button.primary {
   header {
     padding-bottom: 24px;
   }
-  .range-field input[type="range"] {
-    width: 120px;
-  }
-  .phrase-grid {
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  }
   .phrase-button {
     font-size: 1.15rem;
-    padding: 16px;
+    padding: 10px 0;
   }
   .phrase-card {
     min-height: 110px;


### PR DESCRIPTION
## Summary
- remove the redundant page title and volume slider so only the favorites toggle remains in the header
- stretch request cards to the full width with clearer action buttons and move the MP3 status below each card
- keep the last tapped card highlighted even after playback while continuing to queue MP3 generation when required

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e041cda6988323bd3259ed00edfc9f