### PR TITLE
docs: add changelog and bump version to v0.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+Ce document suit les changements notables du projet. Le format est inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/) et respecte la numérotation sémantique.
+
+## [0.02] - 2024-06-20
+### Ajouté
+- Création du journal des modifications pour suivre l'évolution du projet.
+
+### Modifié
+- Mise à jour du numéro de version affiché dans l'interface pour refléter la nouvelle itération.
+- Récapitulation des ajouts récents : stabilisation du workflow GitHub Pages et refonte de l'interface de gestion des phrases et de la synthèse vocale.
+
+## [0.01] - 2024-05-01
+### Ajouté
+- Première version rendue publique avec la gestion des demandes, des favoris et la génération de fichiers audio ElevenLabs stockés en cache.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <span class="icon">★</span>
         Favoris d'abord
       </button>
-      <span class="app-version" aria-label="Version de l'application">v0.01</span>
+      <span class="app-version" aria-label="Version de l'application">v0.02</span>
     </header>
 
     <main>


### PR DESCRIPTION
## Summary
- create an initial CHANGELOG.md following the Keep a Changelog format
- document recent interface and workflow updates and note the version bump to 0.02
- update the in-app version badge to display v0.02

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15db9bd9c832394bce5b6ccf787bd